### PR TITLE
Fix time-based cache clearing to work as intended

### DIFF
--- a/pChart/pCache/pCacheSQLite.php
+++ b/pChart/pCache/pCacheSQLite.php
@@ -151,7 +151,7 @@ class pCacheSQLite implements pCacheInterface
 			if ($ID != "") {
 				$statement = "DELETE FROM cache WHERE Id= :Id;";
 			} else {
-				$statement = "DELETE FROM cache WHERE time > :from;";
+				$statement = "DELETE FROM cache WHERE time < :from;";
 			}
 			$q = $this->DbSQLite->prepare($statement);
 			$q->bindParam(':Id', $ID, \PDO::PARAM_STR);


### PR DESCRIPTION
Time-based cache clearing was removing stuff NEWER than the expiration, not older. Fixed the comparison.